### PR TITLE
Add 10 new MCP tools, Plaid support, and Vitest test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test:client": "tsx scripts/test-client.ts"
+    "test:client": "tsx scripts/test-client.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [
     "mcp",
@@ -26,7 +29,9 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@types/node": "^20.11.0",
+    "@vitest/coverage-v8": "^4.1.1",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerTransactionTools } from "./tools/transactions.js";
 import { registerRecurringTools } from "./tools/recurring.js";
 import { registerBudgetTools } from "./tools/budgets.js";
 import { registerAssetTools } from "./tools/assets.js";
+import { registerPlaidTools } from "./tools/plaid.js";
 
 // Load environment variables
 const apiToken = process.env.LUNCH_MONEY_API_TOKEN;
@@ -103,6 +104,7 @@ registerTransactionTools(mcpServer, client);
 registerRecurringTools(mcpServer, client);
 registerBudgetTools(mcpServer, client);
 registerAssetTools(mcpServer, client);
+registerPlaidTools(mcpServer, client);
 
 // Start FastMCP server
 mcpServer.start({

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -151,6 +151,38 @@ export const updateAssetSchema = z.object({
   institution_name: z.string().optional(),
 });
 
+// Transaction group schemas
+export const createTransactionGroupSchema = z.object({
+  date: z.string(),
+  payee: z.string(),
+  transactions: z.array(z.number()).min(2),
+  category_id: z.number().optional(),
+  notes: z.string().optional(),
+  tags: z.array(z.number()).optional(),
+});
+
+export const unsplitTransactionsSchema = z.object({
+  parent_ids: z.array(z.number()).min(1),
+  remove_parents: z.boolean().optional(),
+});
+
+// Category group schemas
+export const createCategoryGroupSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  is_income: z.boolean().optional(),
+  exclude_from_budget: z.boolean().optional(),
+  exclude_from_totals: z.boolean().optional(),
+  category_ids: z.array(z.number()).optional(),
+  new_categories: z.array(z.string()).optional(),
+});
+
+export const addToGroupSchema = z.object({
+  group_id: z.number().int().positive(),
+  category_ids: z.array(z.number()).optional(),
+  new_categories: z.array(z.string()).optional(),
+});
+
 // ID parameter schemas
 export const idSchema = z.object({
   id: z.number().int().positive(),

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -5,9 +5,11 @@ import { formatErrorForMCP } from "../utils/errors.js";
 import {
   createCategorySchema,
   updateCategorySchema,
+  createCategoryGroupSchema,
+  addToGroupSchema,
   idSchema,
 } from "../schemas/index.js";
-import { CategoriesResponse, Category } from "../types/index.js";
+import { CategoriesResponse, Category, CategoryGroup } from "../types/index.js";
 
 export function registerCategoryTools(
   server: FastMCP,
@@ -70,6 +72,56 @@ export function registerCategoryTools(
       try {
         await client.delete(`/categories/${args.id}`);
         return `Category ${args.id} deleted successfully`;
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "getCategory",
+    description: "Get a single category by ID",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        const category = await client.get<Category>(
+          `/categories/${args.id}`
+        );
+        return JSON.stringify(category, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "createCategoryGroup",
+    description: "Create a new category group with an optional list of category IDs",
+    parameters: createCategoryGroupSchema,
+    execute: async (args: z.infer<typeof createCategoryGroupSchema>) => {
+      try {
+        const response = await client.post<{ category_group: CategoryGroup }>(
+          "/categories/group",
+          args
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "addToGroup",
+    description: "Add existing categories to a category group",
+    parameters: addToGroupSchema,
+    execute: async (args: z.infer<typeof addToGroupSchema>) => {
+      try {
+        const response = await client.post(
+          `/categories/group/${args.group_id}/add`,
+          { category_ids: args.category_ids }
+        );
+        return JSON.stringify(response, null, 2);
       } catch (error) {
         return formatErrorForMCP(error);
       }

--- a/src/tools/plaid.ts
+++ b/src/tools/plaid.ts
@@ -1,0 +1,39 @@
+import { FastMCP } from "fastmcp";
+import { z } from "zod";
+import { LunchMoneyClient } from "../api/client.js";
+import { formatErrorForMCP } from "../utils/errors.js";
+import { PlaidAccountsResponse } from "../types/index.js";
+
+export function registerPlaidTools(
+  server: FastMCP,
+  client: LunchMoneyClient
+) {
+  server.addTool({
+    name: "getPlaidAccounts",
+    description: "List all Plaid-connected accounts with balances",
+    parameters: z.object({}),
+    execute: async () => {
+      try {
+        const response =
+          await client.get<PlaidAccountsResponse>("/plaid_accounts");
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "fetchPlaidAccounts",
+    description: "Trigger a Plaid sync to update account balances",
+    parameters: z.object({}),
+    execute: async () => {
+      try {
+        const response = await client.post<boolean>("/plaid_accounts/fetch");
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+}

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -7,6 +7,8 @@ import {
   createTransactionSchema,
   updateTransactionSchema,
   bulkUpdateTransactionsSchema,
+  createTransactionGroupSchema,
+  unsplitTransactionsSchema,
   idSchema,
 } from "../schemas/index.js";
 import { TransactionsResponse, Transaction } from "../types/index.js";
@@ -25,6 +27,22 @@ export function registerTransactionTools(
         const response = await client.get<TransactionsResponse>(
           "/transactions",
           args
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "getTransaction",
+    description: "Get a single transaction by ID",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        const response = await client.get<Transaction>(
+          `/transactions/${args.id}`
         );
         return JSON.stringify(response, null, 2);
       } catch (error) {
@@ -94,6 +112,71 @@ export function registerTransactionTools(
           args
         );
         return JSON.stringify(result, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "getTransactionGroup",
+    description: "Retrieve a transaction group with all child transactions",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        const response = await client.get<Transaction>(
+          "/transactions/group",
+          { transaction_id: args.id }
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "createTransactionGroup",
+    description:
+      "Group multiple transaction IDs under a single parent transaction",
+    parameters: createTransactionGroupSchema,
+    execute: async (args: z.infer<typeof createTransactionGroupSchema>) => {
+      try {
+        const response = await client.post<Transaction>(
+          "/transactions/group",
+          args
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "deleteTransactionGroup",
+    description:
+      "Delete a transaction group, restoring individual transactions",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        await client.delete(`/transactions/group/${args.id}`);
+        return `Transaction group ${args.id} deleted successfully`;
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "unsplitTransactions",
+    description:
+      "Reverse a split, merging child transactions back into parent",
+    parameters: unsplitTransactionsSchema,
+    execute: async (args: z.infer<typeof unsplitTransactionsSchema>) => {
+      try {
+        const response = await client.post("/transactions/unsplit", args);
+        return JSON.stringify(response, null, 2);
       } catch (error) {
         return formatErrorForMCP(error);
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,3 +158,32 @@ export interface BudgetsResponse {
 export interface AssetsResponse {
     assets: Asset[];
 }
+
+// Plaid account types
+export interface PlaidAccount {
+    id: number;
+    date_linked: string;
+    name: string;
+    display_name?: string;
+    type: string;
+    subtype: string;
+    mask: string;
+    institution_name: string;
+    status: string;
+    balance: string;
+    currency: string;
+    balance_last_update: string;
+    limit?: number;
+    plaid_item_id?: number;
+    linked_by_name?: string;
+    allow_transaction_modifications?: boolean;
+    to_base?: number;
+    import_start_date?: string;
+    last_import?: string;
+    last_fetch?: string;
+    plaid_last_successful_update?: string;
+}
+
+export interface PlaidAccountsResponse {
+    plaid_accounts: PlaidAccount[];
+}

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createJsonResponse(data: unknown, status = 200, ok = true) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: vi.fn().mockResolvedValue(data),
+    text: vi.fn().mockResolvedValue(JSON.stringify(data)),
+  };
+}
+
+function createErrorResponse(
+  status: number,
+  statusText: string,
+  errorBody?: { error: string }
+) {
+  const bodyText = errorBody ? JSON.stringify(errorBody) : statusText;
+  return {
+    ok: false,
+    status,
+    statusText,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: errorBody
+      ? vi.fn().mockResolvedValue(errorBody)
+      : vi.fn().mockRejectedValue(new Error("Not JSON")),
+    text: vi.fn().mockResolvedValue(bodyText),
+  };
+}
+
+describe("LunchMoneyClient", () => {
+  let client: LunchMoneyClient;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new LunchMoneyClient("test-api-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws if no access token is provided", () => {
+      expect(() => new LunchMoneyClient("")).toThrow(
+        "Lunch Money API token is required"
+      );
+    });
+
+    it("creates client with valid token", () => {
+      const c = new LunchMoneyClient("valid-token");
+      expect(c).toBeInstanceOf(LunchMoneyClient);
+    });
+  });
+
+  describe("get", () => {
+    it("makes GET request without params", async () => {
+      const mockData = { user: { id: 1, name: "Test" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.get("/me");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/me",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes GET request with params", async () => {
+      const mockData = { transactions: [] };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      await client.get("/transactions", {
+        start_date: "2024-01-01",
+        limit: 10,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/transactions?start_date=2024-01-01&limit=10",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+
+    it("omits null and undefined params", async () => {
+      const mockData = { transactions: [] };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      await client.get("/transactions", {
+        start_date: "2024-01-01",
+        end_date: undefined,
+        category_id: null,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/transactions?start_date=2024-01-01",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+  });
+
+  describe("post", () => {
+    it("makes POST request with body", async () => {
+      const mockData = { tag: { id: 1, name: "test" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.post("/tags", { name: "test" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "test" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes POST request without body", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse(true));
+
+      await client.post("/plaid_accounts/fetch");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/plaid_accounts/fetch",
+        expect.objectContaining({
+          method: "POST",
+          body: undefined,
+        })
+      );
+    });
+  });
+
+  describe("put", () => {
+    it("makes PUT request with body", async () => {
+      const mockData = { tag: { id: 1, name: "updated" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.put("/tags/1", { name: "updated" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ name: "updated" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes PUT request without body", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      await client.put("/tags/1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: undefined,
+        })
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("makes DELETE request", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      await client.delete("/tags/1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws LunchMoneyAPIError with error message from API response", async () => {
+      mockFetch.mockResolvedValue(
+        createErrorResponse(401, "Unauthorized", {
+          error: "Invalid API key",
+        })
+      );
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow("Invalid API key");
+    });
+
+    it("throws LunchMoneyAPIError with statusText when response is not JSON", async () => {
+      const response = {
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({ "content-type": "text/plain" }),
+        json: vi.fn().mockRejectedValue(new Error("Not JSON")),
+        text: vi.fn().mockResolvedValue("Server error"),
+      };
+      mockFetch.mockResolvedValue(response);
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow(
+        "API request failed: Internal Server Error"
+      );
+    });
+
+    it("throws LunchMoneyAPIError with status code", async () => {
+      mockFetch.mockResolvedValue(
+        createErrorResponse(429, "Too Many Requests", {
+          error: "Rate limited",
+        })
+      );
+
+      try {
+        await client.get("/me");
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(LunchMoneyAPIError);
+        expect((err as LunchMoneyAPIError).statusCode).toBe(429);
+        expect((err as LunchMoneyAPIError).message).toBe("Rate limited");
+      }
+    });
+
+    it("wraps network errors in LunchMoneyAPIError", async () => {
+      mockFetch.mockRejectedValue(new Error("fetch failed"));
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow("fetch failed");
+    });
+
+    it("wraps non-Error throws in LunchMoneyAPIError", async () => {
+      mockFetch.mockRejectedValue("unexpected string");
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow(
+        "Unknown error occurred"
+      );
+    });
+
+    it("returns empty object for non-JSON successful response", async () => {
+      const response = {
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        headers: new Headers({ "content-type": "text/plain" }),
+        json: vi.fn(),
+        text: vi.fn().mockResolvedValue(""),
+      };
+      mockFetch.mockResolvedValue(response);
+
+      const result = await client.delete("/tags/1");
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/tests/tools/assets.test.ts
+++ b/tests/tools/assets.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerAssetTools } from "../../src/tools/assets.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { AssetsResponse, Asset } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Asset tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerAssetTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getAssets",
+      "createAsset",
+      "updateAsset",
+      "deleteAsset",
+    ]);
+  });
+
+  describe("getAssets", () => {
+    it("returns JSON stringified assets on success", async () => {
+      const mockResponse: AssetsResponse = {
+        assets: [
+          {
+            id: 1,
+            type_name: "cash",
+            name: "Emergency Fund",
+            balance: "10000.00",
+            currency: "usd",
+            institution_name: "Ally Bank",
+            created_at: "2024-01-01T00:00:00.000Z",
+          },
+          {
+            id: 2,
+            type_name: "investment",
+            name: "401k",
+            balance: "50000.00",
+            currency: "usd",
+            institution_name: "Fidelity",
+            created_at: "2024-02-01T00:00:00.000Z",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/assets");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createAsset", () => {
+    it("returns JSON stringified asset on success", async () => {
+      const mockResponse: { asset: Asset } = {
+        asset: {
+          id: 3,
+          type_name: "real estate",
+          name: "Home",
+          balance: "350000.00",
+          currency: "usd",
+          created_at: "2024-03-01T00:00:00.000Z",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const args = {
+        type_name: "real estate",
+        name: "Home",
+        balance: "350000.00",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/assets", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateAsset", () => {
+    it("returns JSON stringified updated asset on success", async () => {
+      const mockResponse: { asset: Asset } = {
+        asset: {
+          id: 1,
+          type_name: "cash",
+          name: "Emergency Fund",
+          balance: "12000.00",
+          currency: "usd",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/assets/1", {
+        balance: "12000.00",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 999, balance: "12000.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteAsset", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/assets/2");
+      expect(result).toBe("Asset 2 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/budgets.test.ts
+++ b/tests/tools/budgets.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerBudgetTools } from "../../src/tools/budgets.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { BudgetsResponse, Budget } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Budget tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerBudgetTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getBudgets",
+      "createBudget",
+      "updateBudget",
+      "deleteBudget",
+    ]);
+  });
+
+  describe("getBudgets", () => {
+    it("returns JSON stringified budgets on success", async () => {
+      const mockResponse: BudgetsResponse = {
+        budgets: [
+          {
+            id: 1,
+            category_id: 10,
+            category_name: "Groceries",
+            amount: "500.00",
+            currency: "usd",
+            start_date: "2024-01-01",
+            end_date: "2024-01-31",
+          },
+          {
+            id: 2,
+            category_id: 20,
+            category_name: "Entertainment",
+            amount: "200.00",
+            currency: "usd",
+            start_date: "2024-01-01",
+            end_date: "2024-01-31",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/budgets");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createBudget", () => {
+    it("returns JSON stringified budget on success", async () => {
+      const mockResponse: { budget: Budget } = {
+        budget: {
+          id: 3,
+          category_id: 30,
+          category_name: "Transport",
+          amount: "150.00",
+          currency: "usd",
+          start_date: "2024-02-01",
+          end_date: "2024-02-29",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const args = {
+        category_id: 30,
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/budgets", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateBudget", () => {
+    it("returns JSON stringified updated budget on success", async () => {
+      const mockResponse: { budget: Budget } = {
+        budget: {
+          id: 1,
+          category_id: 10,
+          category_name: "Groceries",
+          amount: "600.00",
+          currency: "usd",
+          start_date: "2024-01-01",
+          end_date: "2024-01-31",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/budgets/1", {
+        amount: "600.00",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 999, amount: "600.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteBudget", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/budgets/2");
+      expect(result).toBe("Budget 2 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/categories.test.ts
+++ b/tests/tools/categories.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerCategoryTools } from "../../src/tools/categories.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type {
+  CategoriesResponse,
+  Category,
+  CategoryGroup,
+} from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Category tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerCategoryTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers seven tools", () => {
+    expect(tools).toHaveLength(7);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getCategories",
+      "createCategory",
+      "updateCategory",
+      "deleteCategory",
+      "getCategory",
+      "createCategoryGroup",
+      "addToGroup",
+    ]);
+  });
+
+  // ── getCategories ──────────────────────────────────────────────
+
+  describe("getCategories", () => {
+    it("returns JSON stringified categories on success", async () => {
+      const mockResponse: CategoriesResponse = {
+        categories: [
+          {
+            id: 1,
+            name: "Food",
+            description: "Groceries and dining",
+            is_income: false,
+            exclude_budget: false,
+            exclude_from_totals: false,
+            archived: false,
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getCategories")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/categories");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getCategories")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getCategories")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getCategories")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── getCategory ────────────────────────────────────────────────
+
+  describe("getCategory", () => {
+    it("returns JSON stringified category on success", async () => {
+      const mockCategory: Category = {
+        id: 42,
+        name: "Transport",
+        description: "Public transit and rideshares",
+        is_income: false,
+      };
+
+      mockClient.get.mockResolvedValue(mockCategory);
+
+      const tool = tools.find((t) => t.name === "getCategory")!;
+      const result = await tool.execute({ id: 42 });
+
+      expect(mockClient.get).toHaveBeenCalledWith("/categories/42");
+      expect(result).toBe(JSON.stringify(mockCategory, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "getCategory")!;
+      const result = await tool.execute({ id: 999 });
+
+      expect(result).toBe("Lunch Money API Error: Not Found (Status: 404)");
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getCategory")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "getCategory")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── createCategory ─────────────────────────────────────────────
+
+  describe("createCategory", () => {
+    it("returns JSON stringified created category on success", async () => {
+      const mockResponse = {
+        category: { id: 10, name: "Subscriptions" } as Category,
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createCategory")!;
+      const result = await tool.execute({
+        name: "Subscriptions",
+        is_income: false,
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith("/categories", {
+        name: "Subscriptions",
+        is_income: false,
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createCategory")!;
+      const result = await tool.execute({ name: "Test" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Timeout"));
+
+      const tool = tools.find((t) => t.name === "createCategory")!;
+      const result = await tool.execute({ name: "Test" });
+
+      expect(result).toBe("Error: Timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "createCategory")!;
+      const result = await tool.execute({ name: "Test" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── updateCategory ─────────────────────────────────────────────
+
+  describe("updateCategory", () => {
+    it("returns JSON stringified updated category on success", async () => {
+      const mockResponse = {
+        category: { id: 5, name: "Dining Out" } as Category,
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateCategory")!;
+      const result = await tool.execute({ id: 5, name: "Dining Out" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/categories/5", {
+        name: "Dining Out",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateCategory")!;
+      const result = await tool.execute({ id: 999, name: "Nope" });
+
+      expect(result).toBe("Lunch Money API Error: Not Found (Status: 404)");
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Connection reset"));
+
+      const tool = tools.find((t) => t.name === "updateCategory")!;
+      const result = await tool.execute({ id: 1, name: "Updated" });
+
+      expect(result).toBe("Error: Connection reset");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "updateCategory")!;
+      const result = await tool.execute({ id: 1, name: "Updated" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── deleteCategory ─────────────────────────────────────────────
+
+  describe("deleteCategory", () => {
+    it("returns success message on success", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteCategory")!;
+      const result = await tool.execute({ id: 7 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/categories/7");
+      expect(result).toBe("Category 7 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteCategory")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Lunch Money API Error: Forbidden (Status: 403)");
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "deleteCategory")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(false);
+
+      const tool = tools.find((t) => t.name === "deleteCategory")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── createCategoryGroup ────────────────────────────────────────
+
+  describe("createCategoryGroup", () => {
+    it("returns JSON stringified category group on success", async () => {
+      const mockResponse = {
+        category_group: {
+          id: 100,
+          name: "Fixed Expenses",
+          created_at: "2024-06-01T00:00:00.000Z",
+        } as CategoryGroup,
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createCategoryGroup")!;
+      const result = await tool.execute({
+        name: "Fixed Expenses",
+        category_ids: [1, 2, 3],
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith("/categories/group", {
+        name: "Fixed Expenses",
+        category_ids: [1, 2, 3],
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("works without optional category_ids", async () => {
+      const mockResponse = {
+        category_group: { id: 101, name: "Variable" } as CategoryGroup,
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createCategoryGroup")!;
+      const result = await tool.execute({ name: "Variable" });
+
+      expect(mockClient.post).toHaveBeenCalledWith("/categories/group", {
+        name: "Variable",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createCategoryGroup")!;
+      const result = await tool.execute({ name: "Test Group" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "createCategoryGroup")!;
+      const result = await tool.execute({ name: "Test Group" });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue("bad");
+
+      const tool = tools.find((t) => t.name === "createCategoryGroup")!;
+      const result = await tool.execute({ name: "Test Group" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ── addToGroup ─────────────────────────────────────────────────
+
+  describe("addToGroup", () => {
+    it("returns JSON stringified response on success", async () => {
+      const mockResponse = { success: true };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "addToGroup")!;
+      const result = await tool.execute({
+        group_id: 100,
+        category_ids: [4, 5],
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "/categories/group/100/add",
+        { category_ids: [4, 5] }
+      );
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "addToGroup")!;
+      const result = await tool.execute({
+        group_id: 999,
+        category_ids: [1],
+      });
+
+      expect(result).toBe("Lunch Money API Error: Not Found (Status: 404)");
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection refused"));
+
+      const tool = tools.find((t) => t.name === "addToGroup")!;
+      const result = await tool.execute({
+        group_id: 1,
+        category_ids: [2],
+      });
+
+      expect(result).toBe("Error: Connection refused");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(0);
+
+      const tool = tools.find((t) => t.name === "addToGroup")!;
+      const result = await tool.execute({
+        group_id: 1,
+        category_ids: [2],
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/plaid.test.ts
+++ b/tests/tools/plaid.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerPlaidTools } from "../../src/tools/plaid.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { PlaidAccountsResponse } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Plaid tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerPlaidTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers two tools", () => {
+    expect(tools).toHaveLength(2);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getPlaidAccounts",
+      "fetchPlaidAccounts",
+    ]);
+  });
+
+  describe("getPlaidAccounts", () => {
+    it("returns JSON stringified Plaid accounts on success", async () => {
+      const mockResponse: PlaidAccountsResponse = {
+        plaid_accounts: [
+          {
+            id: 1,
+            date_linked: "2024-01-15",
+            name: "Checking Account",
+            display_name: "My Checking",
+            type: "depository",
+            subtype: "checking",
+            mask: "1234",
+            institution_name: "Chase",
+            status: "active",
+            balance: "5000.00",
+            currency: "usd",
+            balance_last_update: "2024-06-01T12:00:00.000Z",
+            limit: undefined,
+          },
+          {
+            id: 2,
+            date_linked: "2024-02-01",
+            name: "Credit Card",
+            type: "credit",
+            subtype: "credit card",
+            mask: "5678",
+            institution_name: "Amex",
+            status: "active",
+            balance: "1500.00",
+            currency: "usd",
+            balance_last_update: "2024-06-01T12:00:00.000Z",
+            limit: 10000,
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/plaid_accounts");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("fetchPlaidAccounts", () => {
+    it("returns JSON stringified boolean on success", async () => {
+      mockClient.post.mockResolvedValue(true);
+
+      const tool = tools.find((t) => t.name === "fetchPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.post).toHaveBeenCalledWith("/plaid_accounts/fetch");
+      expect(result).toBe(JSON.stringify(true, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Rate limited", 429)
+      );
+
+      const tool = tools.find((t) => t.name === "fetchPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Rate limited (Status: 429)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "fetchPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "fetchPlaidAccounts")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/recurring.test.ts
+++ b/tests/tools/recurring.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerRecurringTools } from "../../src/tools/recurring.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type {
+  RecurringItemsResponse,
+  RecurringItem,
+} from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Recurring tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerRecurringTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getRecurringItems",
+      "createRecurringItem",
+      "updateRecurringItem",
+      "deleteRecurringItem",
+    ]);
+  });
+
+  describe("getRecurringItems", () => {
+    it("returns JSON stringified recurring items on success", async () => {
+      const mockResponse: RecurringItemsResponse = {
+        recurring_items: [
+          {
+            id: 1,
+            payee: "Netflix",
+            amount: "15.99",
+            currency: "usd",
+            frequency: "monthly",
+            flow: "outflow",
+            start_date: "2024-01-01",
+          },
+          {
+            id: 2,
+            payee: "Salary",
+            amount: "5000.00",
+            currency: "usd",
+            frequency: "monthly",
+            flow: "inflow",
+            start_date: "2024-01-15",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/recurring_expenses");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createRecurringItem", () => {
+    it("returns JSON stringified recurring item on success", async () => {
+      const mockResponse: { recurring_expense: RecurringItem } = {
+        recurring_expense: {
+          id: 3,
+          payee: "Gym",
+          amount: "50.00",
+          currency: "usd",
+          frequency: "monthly",
+          flow: "outflow",
+          start_date: "2024-03-01",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const args = { payee: "Gym", amount: "50.00", frequency: "monthly", flow: "outflow", start_date: "2024-03-01" };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/recurring_expenses", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateRecurringItem", () => {
+    it("returns JSON stringified updated recurring item on success", async () => {
+      const mockResponse: { recurring_expense: RecurringItem } = {
+        recurring_expense: {
+          id: 1,
+          payee: "Netflix Premium",
+          amount: "22.99",
+          currency: "usd",
+          frequency: "monthly",
+          flow: "outflow",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, payee: "Netflix Premium", amount: "22.99" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/recurring_expenses/1", {
+        payee: "Netflix Premium",
+        amount: "22.99",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 999, amount: "22.99" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, amount: "22.99" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, amount: "22.99" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteRecurringItem", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/recurring_expenses/3");
+      expect(result).toBe("Recurring item 3 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/tags.test.ts
+++ b/tests/tools/tags.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerTagTools } from "../../src/tools/tags.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { TagsResponse, Tag } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Tag tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerTagTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getTags",
+      "createTag",
+      "updateTag",
+      "deleteTag",
+    ]);
+  });
+
+  describe("getTags", () => {
+    it("returns JSON stringified tags on success", async () => {
+      const mockResponse: TagsResponse = {
+        tags: [
+          { id: 1, name: "groceries", created_at: "2024-01-01T00:00:00.000Z" },
+          { id: 2, name: "travel", created_at: "2024-02-01T00:00:00.000Z" },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/tags");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createTag", () => {
+    it("returns JSON stringified tag on success", async () => {
+      const mockResponse: { tag: Tag } = {
+        tag: { id: 3, name: "utilities", created_at: "2024-03-01T00:00:00.000Z" },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(mockClient.post).toHaveBeenCalledWith("/tags", { name: "utilities" });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateTag", () => {
+    it("returns JSON stringified updated tag on success", async () => {
+      const mockResponse: { tag: Tag } = {
+        tag: { id: 1, name: "food", created_at: "2024-01-01T00:00:00.000Z" },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/tags/1", { name: "food" });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 999, name: "food" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteTag", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/tags/5");
+      expect(result).toBe("Tag 5 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/transactions.test.ts
+++ b/tests/tools/transactions.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerTransactionTools } from "../../src/tools/transactions.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type {
+  TransactionsResponse,
+  Transaction,
+} from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+const sampleTransaction: Transaction = {
+  id: 1,
+  date: "2024-06-01",
+  payee: "Starbucks",
+  amount: "5.50",
+  currency: "usd",
+  notes: "Morning coffee",
+  category_id: 10,
+  account_id: 100,
+  status: "cleared",
+  type: "expense",
+};
+
+describe("Transaction tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerTransactionTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers ten tools", () => {
+    expect(tools).toHaveLength(10);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getTransactions",
+      "getTransaction",
+      "createTransaction",
+      "updateTransaction",
+      "deleteTransaction",
+      "bulkUpdateTransactions",
+      "getTransactionGroup",
+      "createTransactionGroup",
+      "deleteTransactionGroup",
+      "unsplitTransactions",
+    ]);
+  });
+
+  // ---------- getTransactions ----------
+  describe("getTransactions", () => {
+    it("returns JSON stringified transactions on success", async () => {
+      const mockResponse: TransactionsResponse = {
+        transactions: [sampleTransaction],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getTransactions")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/transactions", {});
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getTransactions")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+  });
+
+  // ---------- getTransaction ----------
+  describe("getTransaction", () => {
+    it("returns JSON stringified single transaction on success", async () => {
+      mockClient.get.mockResolvedValue(sampleTransaction);
+
+      const tool = tools.find((t) => t.name === "getTransaction")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.get).toHaveBeenCalledWith("/transactions/1");
+      expect(result).toBe(JSON.stringify(sampleTransaction, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Transaction not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "getTransaction")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Transaction not found (Status: 404)"
+      );
+    });
+  });
+
+  // ---------- createTransaction ----------
+  describe("createTransaction", () => {
+    it("returns JSON stringified created transaction on success", async () => {
+      const mockResponse = { transaction: sampleTransaction };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createTransaction")!;
+      const args = {
+        date: "2024-06-01",
+        amount: "5.50",
+        payee: "Starbucks",
+        account_id: 100,
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/transactions", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Validation error", 422)
+      );
+
+      const tool = tools.find((t) => t.name === "createTransaction")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        amount: "5.50",
+        account_id: 100,
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Validation error (Status: 422)"
+      );
+    });
+  });
+
+  // ---------- updateTransaction ----------
+  describe("updateTransaction", () => {
+    it("returns JSON stringified updated transaction on success", async () => {
+      const updatedTransaction = { ...sampleTransaction, payee: "Updated" };
+      const mockResponse = { transaction: updatedTransaction };
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateTransaction")!;
+      const result = await tool.execute({ id: 1, payee: "Updated" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/transactions/1", {
+        payee: "Updated",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateTransaction")!;
+      const result = await tool.execute({ id: 99999, payee: "Updated" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not found (Status: 404)"
+      );
+    });
+  });
+
+  // ---------- deleteTransaction ----------
+  describe("deleteTransaction", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteTransaction")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/transactions/1");
+      expect(result).toBe("Transaction 1 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteTransaction")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not found (Status: 404)"
+      );
+    });
+  });
+
+  // ---------- bulkUpdateTransactions ----------
+  describe("bulkUpdateTransactions", () => {
+    it("returns JSON stringified update count on success", async () => {
+      const mockResponse = { updated: 3 };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "bulkUpdateTransactions")!;
+      const args = {
+        transaction_ids: [1, 2, 3],
+        status: "cleared",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/transactions/bulk", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Server error", 500)
+      );
+
+      const tool = tools.find((t) => t.name === "bulkUpdateTransactions")!;
+      const result = await tool.execute({
+        transaction_ids: [1, 2, 3],
+        status: "cleared",
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Server error (Status: 500)"
+      );
+    });
+  });
+
+  // ---------- getTransactionGroup ----------
+  describe("getTransactionGroup", () => {
+    it("returns JSON stringified transaction group on success", async () => {
+      const groupTransaction: Transaction = {
+        ...sampleTransaction,
+        is_group: true,
+        subtransactions: [
+          { ...sampleTransaction, id: 2, group_id: 1 },
+          { ...sampleTransaction, id: 3, group_id: 1 },
+        ],
+      };
+      mockClient.get.mockResolvedValue(groupTransaction);
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.get).toHaveBeenCalledWith("/transactions/group", { transaction_id: 1 });
+      expect(result).toBe(JSON.stringify(groupTransaction, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Group not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Group not found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- createTransactionGroup ----------
+  describe("createTransactionGroup", () => {
+    it("returns JSON stringified group transaction on success", async () => {
+      const groupTransaction: Transaction = {
+        ...sampleTransaction,
+        is_group: true,
+        subtransactions: [
+          { ...sampleTransaction, id: 2, group_id: 1 },
+          { ...sampleTransaction, id: 3, group_id: 1 },
+        ],
+      };
+      mockClient.post.mockResolvedValue(groupTransaction);
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const args = {
+        date: "2024-06-01",
+        payee: "Grouped Transaction",
+        transactions: [2, 3],
+        category_id: 10,
+        notes: "Grouped for tracking",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "/transactions/group",
+        args
+      );
+      expect(result).toBe(JSON.stringify(groupTransaction, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Validation error", 422)
+      );
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Bad Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Validation error (Status: 422)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- deleteTransactionGroup ----------
+  describe("deleteTransactionGroup", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith(
+        "/transactions/group/1"
+      );
+      expect(result).toBe("Transaction group 1 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Group not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Group not found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- unsplitTransactions ----------
+  describe("unsplitTransactions", () => {
+    it("returns JSON stringified response on success", async () => {
+      const mockResponse = { parent_ids: [1], transactions: [sampleTransaction] };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const args = { parent_ids: [1] };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "/transactions/unsplit",
+        args
+      );
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Cannot unsplit", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [99999] });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Cannot unsplit (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [1] });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [1] });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/user.test.ts
+++ b/tests/tools/user.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerUserTools } from "../../src/tools/user.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { User } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("User tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerUserTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers one tool", () => {
+    expect(tools).toHaveLength(1);
+    expect(tools.map((t) => t.name)).toEqual(["getUser"]);
+  });
+
+  describe("getUser", () => {
+    it("returns JSON stringified user on success", async () => {
+      const mockUser: User = {
+        id: 1,
+        email: "test@example.com",
+        name: "Test User",
+        currency: "usd",
+        budget_display_order: [1, 2, 3],
+        date_format: "MM/DD/YYYY",
+        first_day_of_week: 0,
+        beta_user: false,
+        created_at: "2024-01-01T00:00:00.000Z",
+      };
+
+      mockClient.get.mockResolvedValue(mockUser);
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/me");
+      expect(result).toBe(JSON.stringify(mockUser, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/tools/**", "src/api/**", "src/utils/**"],
+      reporter: ["text", "lcov"],
+      thresholds: {
+        // Coverage thresholds are enforced per tested file.
+        // Files without tests are not blocked; thresholds ramp up
+        // as subsequent tasks add test suites.
+        perFile: true,
+        "src/tools/plaid.ts": {
+          lines: 90,
+          functions: 90,
+          branches: 90,
+          statements: 90,
+        },
+        "src/utils/errors.ts": {
+          lines: 60,
+          functions: 60,
+          branches: 50,
+          statements: 60,
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add 10 new MCP tools covering Lunch Money API endpoints that were missing
- Add comprehensive Vitest test suite with 157 tests and >90% coverage
- Add Zod schemas and TypeScript types for all new endpoints

## New Tools

### Plaid Accounts
| Tool | API Endpoint | Description |
|------|-------------|-------------|
| getPlaidAccounts | GET /v1/plaid_accounts | List Plaid-connected accounts with balances |
| fetchPlaidAccounts | POST /v1/plaid_accounts/fetch | Trigger Plaid balance sync |

### Transactions
| Tool | API Endpoint | Description |
|------|-------------|-------------|
| getTransaction | GET /v1/transactions/:id | Get single transaction |
| getTransactionGroup | GET /v1/transactions/group | Get transaction group with children |
| createTransactionGroup | POST /v1/transactions/group | Group transactions under a parent |
| deleteTransactionGroup | DELETE /v1/transactions/group/:id | Ungroup a transaction group |
| unsplitTransactions | POST /v1/transactions/unsplit | Reverse a transaction split |

### Categories
| Tool | API Endpoint | Description |
|------|-------------|-------------|
| getCategory | GET /v1/categories/:id | Get single category |
| createCategoryGroup | POST /v1/categories/group | Create a category group |
| addToGroup | POST /v1/categories/group/:id/add | Add categories to a group |

## Test Suite
- **Framework:** Vitest 4.x with @vitest/coverage-v8
- **Tests:** 9 test files, 157 tests, all passing
- **Coverage:** >90% on all tool modules (most at 100%)
- **Approach:** Mock-based unit tests — no live API calls
- **Files tested:** All 8 tool modules + API client + error utilities

## Changes
- `src/tools/plaid.ts` — new Plaid accounts module
- `src/tools/transactions.ts` — added 5 new tools (getTransaction, grouping, unsplit)
- `src/tools/categories.ts` — added 3 new tools (getCategory, group management)
- `src/schemas/index.ts` — added Zod schemas for new endpoints
- `src/types/index.ts` — added PlaidAccount types
- `src/index.ts` — registered Plaid tools
- `package.json` — added Vitest devDependencies and test scripts
- `vitest.config.ts` — test configuration with coverage
- `tests/` — 9 comprehensive test files